### PR TITLE
Update json format and add tests in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,19 @@
 sudo: false
 language: cpp
-python:
-  - "3.6"
 matrix:
   include:
+    - os: linux
+      dist: trusty
+      sudo: require
+      addons:
+        apt:
+          sources: [deadsnakes]
+          packages: [python3.6-dev]
+      env:
+        - DESC="Check json"
+        - TEST="true"
+        - PYTHON=3.6
+
     - os: linux
       dist: trusty
       sudo: require
@@ -26,8 +36,17 @@ matrix:
         - MATRIX_EVAL="COMPILER=clang++"
 
 install:
-- pip install --user --upgrade pip;
-- pip install --user jinja2;
+- if [ ! -z $TEST ]; then
+    cd src/protocol/templates;
+    echo "CHECK JSON";
+    python3.6 -m json.tool ping_protocol.json >> temp.json;
+    echo "CHECK JSON STYLE";
+    comm -2 -3 ping_protocol.json temp.json;
+  fi
+- if [ -z $TEST ]; then
+    pip install --user --upgrade pip;
+    pip install --user jinja2;
+  fi
 - if [[ "${TRAVIS_OS_NAME}" = "linux" && -z $TEST ]]; then
     if [ "${QTV}" = "qt59" ]; then
       sudo add-apt-repository --yes ppa:beineri/opt-qt594-trusty;
@@ -48,11 +67,13 @@ install:
   fi
 
 script:
-- if [ "${TRAVIS_OS_NAME}" = "linux" ]; then
+- if [[ "${TRAVIS_OS_NAME}" = "linux" && -z $TEST ]]; then
     source /opt/qt*/bin/qt*-env.sh;
   fi
-- cd example;
-- mkdir build;
-- cd build;
-- qmake .. -Wall -Wlogic -Wparser;
-- make;
+- if [ -z $TEST ]; then
+    cd example;
+    mkdir build;
+    cd build;
+    qmake .. -Wall -Wlogic -Wparser;
+    make;
+  fi

--- a/src/protocol/templates/ping_protocol.json
+++ b/src/protocol/templates/ping_protocol.json
@@ -1,511 +1,511 @@
 {
-  "class_info": {
-    "_comment": "Handle the main class protocol, the class name will be the file prefix in lower",
-    "file": "pingmessage.h.in",
-    "name": "PingMessage"
-  },
-  "subclass_info": {
-    "_comment": "Create a class for each message type",
-    "file": "pingmessage_.h.in",
-    "name": "ping_msg_"
-  },
-  "sensor_info": {
-    "file": "ping.h.in",
-    "name": "Ping"
-  },
-  "requirements": {
-    "discovery": "discovery of connected devices, types, and firmwares",
-    "packed fields": "memory alignment"
-  },
-  "format": [
-    {
-      "name": "start1",
-      "type": "u8",
-      "index": "0"
+    "class_info": {
+        "_comment": "Handle the main class protocol, the class name will be the file prefix in lower",
+        "file": "pingmessage.h.in",
+        "name": "PingMessage"
     },
-    {
-      "name": "start2",
-      "type": "u8",
-      "index": "1"
+    "subclass_info": {
+        "_comment": "Create a class for each message type",
+        "file": "pingmessage_.h.in",
+        "name": "ping_msg_"
     },
-    {
-      "name": "length",
-      "type": "u16",
-      "index": "2-3"
+    "sensor_info": {
+        "file": "ping.h.in",
+        "name": "Ping"
     },
-    {
-      "name": "message_id",
-      "type": "u16",
-      "index": "4-5"
+    "requirements": {
+        "discovery": "discovery of connected devices, types, and firmwares",
+        "packed fields": "memory alignment"
     },
-    {
-      "name": "src_device_id",
-      "type": "u8",
-      "index": "6"
-    },
-    {
-      "name": "dst_device_id",
-      "type": "u8",
-      "index": "7"
-    },
-    {
-      "name": "payload",
-      "type": "u8[]",
-      "index": "8-n"
-    },
-    {
-      "name": "checksum",
-      "type": "u16",
-      "index": "(n+1)-(n+2)"
-    }
-  ],
-  "messages": {
-    "ping1D": {
-      "undefined": {
-        "id": "0",
-        "payload": []
-      },
-      "ack": {
-        "id": "1",
-        "payload": []
-      },
-      "nack": {
-        "id": "2",
-        "payload": []
-      },
-      "ascii_text": {
-        "id": "3",
-        "payload": []
-      },
-      "set_device_id": {
-        "id": "1000",
-        "payload": [
-          {
-            "name": "device_id",
-            "type": "u8"
-          }
-        ]
-      },
-      "set_range": {
-        "id": "1001",
-        "payload": [
-          {
-            "name": "start_mm",
-            "type": "u8"
-          },
-          {
-            "name": "length_mm",
-            "type": "u8"
-          }
-        ]
-      },
-      "set_speed_of_sound": {
-        "id": "1002",
-        "payload": [
-          {
-            "name": "speed",
-            "type": "u32"
-          }
-        ]
-      },
-      "set_auto_manual": {
-        "id": "1003",
-        "payload": [
-          {
-            "name": "mode",
-            "type": "u8"
-          }
-        ]
-      },
-      "set_ping_rate_msec": {
-        "id": "1004",
-        "payload": [
-          {
-            "name": "rate_msec",
-            "type": "u16"
-          }
-        ]
-      },
-      "set_gain_index": {
-        "id": "1005",
-        "payload": [
-          {
-            "name": "index",
-            "type": "u8"
-          }
-        ]
-      },
-      "set_ping_enable": {
-        "id": "1006",
-        "payload": [
-          {
-            "name": "enable",
-            "type": "u8"
-          }
-        ]
-      },
-      "goto_bootloader": {
-        "id": "1100",
-        "payload": []
-      },
-      "fw_version": {
-        "id": "1200",
-        "payload": [
-          {
-            "name": "device_type",
-            "type": "u8"
-          },
-          {
-            "name": "device_model",
-            "type": "u8"
-          },
-          {
-            "name": "fw_version_major",
-            "type": "u16"
-          },
-          {
-            "name": "fw_version_minor",
-            "type": "u16"
-          }
-        ]
-      },
-      "device_id": {
-        "id": "1201",
-        "payload": [],
-        "deprecated": "true"
-      },
-      "voltage_5": {
-        "id": "1202",
-        "payload": [
-          {
-            "name": "mvolts",
-            "type": "u16"
-          }
-        ]
-      },
-      "speed_of_sound": {
-        "id": "1203",
-        "payload": [
-          {
-            "name": "speed_mmps",
-            "type": "u32"
-          }
-        ]
-      },
-      "range": {
-        "id": "1204",
-        "payload": [
-          {
-            "name": "start_mm",
-            "type": "u32"
-          },
-          {
-            "name": "length_mm",
-            "type": "u32"
-          }
-        ]
-      },
-      "mode": {
-        "id": "1205",
-        "payload": [
-          {
-            "name": "auto_manual",
-            "type": "u8"
-          }
-        ]
-      },
-      "ping_rate_msec": {
-        "id": "1206",
-        "payload": [
-          {
-            "name": "msec_per_ping",
-            "type": "u16"
-          }
-        ]
-      },
-      "gain_index": {
-        "id": "1207",
-        "payload": [
-          {
-            "name": "gain_index",
-            "type": "u8"
-          }
-        ]
-      },
-      "pulse_usec": {
-        "id": "1208",
-        "payload": [
-          {
-            "name": "pulse_usec",
-            "type": "u16"
-          }
-        ]
-      },
-      "background_data": {
-        "id": "1209",
-        "payload": [
-          {
-            "name": "gain_index",
-            "type": "u8"
-          }
-        ]
-      },
-      "general_info": {
-        "id": "1210",
-        "payload": [
-          {
-            "name": "gain_index",
-            "type": "u8"
-          }
-        ]
-      },
-      "distance_simple": {
-        "id": "1211",
-        "payload": [
-          {
-            "name": "distance",
-            "type": "u32"
-          },
-          {
-            "name": "confidence",
-            "type": "u8"
-          }
-        ]
-      },
-      "distance": {
-        "id": "1212",
-        "payload": [
-          {
-            "name": "distance",
-            "type": "u32"
-          },
-          {
-            "name": "confidence",
-            "type": "u8"
-          },
-          {
-            "name": "pulse_usec",
-            "type": "u16"
-          },
-          {
-            "name": "ping_number",
-            "type": "u32"
-          },
-          {
-            "name": "start_mm",
-            "type": "u32"
-          },
-          {
-            "name": "length_mm",
-            "type": "u32"
-          },
-          {
-            "name": "gain_index",
-            "type": "u32"
-          }
-        ]
-      },
-      "processor_temperature": {
-        "id": "1213",
-        "payload": [
-          {
-            "name": "temp",
+    "format": [
+        {
+            "name": "start1",
+            "type": "u8",
+            "index": "0"
+        },
+        {
+            "name": "start2",
+            "type": "u8",
+            "index": "1"
+        },
+        {
+            "name": "length",
             "type": "u16",
-            "units": "centiC",
-            "notes": "100 * degrees Centigrade"
-          }
-        ]
-      },
-      "pcb_temperature": {
-        "id": "1214",
-        "payload": [
-          {
-            "name": "temp",
+            "index": "2-3"
+        },
+        {
+            "name": "message_id",
             "type": "u16",
-            "units": "centiC",
-            "notes": "PCB Board temperature, 100 * degrees Centigrade"
-          }
-        ]
-      },
-      "profile": {
-        "id": "1300",
-        "payload": [
-          {
-            "name": "distance",
-            "type": "u32"
-          },
-          {
-            "name": "confidence",
-            "type": "u16"
-          },
-          {
-            "name": "pulse_usec",
-            "type": "u16"
-          },
-          {
-            "name": "ping_number",
-            "type": "u32"
-          },
-          {
-            "name": "start_mm",
-            "type": "u32"
-          },
-          {
-            "name": "length_mm",
-            "type": "u32"
-          },
-          {
-            "name": "gain_index",
-            "type": "u32"
-          },
-          {
-            "name": "num_points",
-            "type": "u16"
-          },
-          {
-            "name": "data",
-            "type": "u8[200]"
-          }
-        ]
-      },
-      "full_profile": {
-        "id": "1301",
-        "payload": [
-          {
-            "name": "this_ping_depth_mm",
-            "type": "i32"
-          },
-          {
-            "name": "smoothed_depth_mm",
-            "type": "i32"
-          },
-          {
-            "name": "smoothed_depth_confidence_percent",
-            "type": "i8"
-          },
-          {
-            "name": "this_ping_confidence_percent",
-            "type": "i8"
-          },
-          {
-            "name": "ping_duration_usec",
-            "type": "i16"
-          },
-          {
-            "name": "ping_number",
-            "type": "i32"
-          },
-          {
-            "name": "supply_millivolts",
-            "type": "u16"
-          },
-          {
-            "name": "degC",
-            "type": "u16"
-          },
-          {
-            "name": "start_mm",
-            "type": "i32"
-          },
-          {
-            "name": "length_mm",
-            "type": "i32"
-          },
-          {
-            "name": "y0_mm",
-            "type": "i32"
-          },
-          {
-            "name": "yn_mm",
-            "type": "i32"
-          },
-          {
-            "name": "gain_index",
-            "type": "i32"
-          },
-          {
-            "name": "outlier_bits",
-            "type": "u32"
-          },
-          {
-            "name": "index_of_bottom_result",
-            "type": "i16"
-          },
-          {
-            "name": "num_results",
-            "type": "i16"
-          },
-          {
-            "name": "results",
-            "type": "u8[200]"
-          }
-        ]
-      },
-      "raw_data": {
-        "id": "1302",
-        "payload": [
-          {
-            "name": "v_major",
-            "type": "u32"
-          },
-          {
-            "name": "v_minor",
-            "type": "u32"
-          },
-          {
-            "name": "supply_millivolts",
-            "type": "u16"
-          },
-          {
-            "name": "degC",
-            "type": "u16"
-          },
-          {
-            "name": "gain_index",
-            "type": "u32"
-          },
-          {
-            "name": "start_mm",
-            "type": "u32"
-          },
-          {
-            "name": "len_mm",
-            "type": "u32"
-          },
-          {
-            "name": "num_samples",
-            "type": "u32"
-          },
-          {
-            "name": "ping_usec",
-            "type": "u32"
-          },
-          {
-            "name": "ping_hz",
-            "type": "u32"
-          },
-          {
-            "name": "adc_sample_hz",
-            "type": "u32"
-          },
-          {
-            "name": "ping_num",
-            "type": "u32"
-          },
-          {
-            "name": "rms_goertzel_noise",
-            "type": "u32"
-          }
-        ]
-      },
-      "continuous_start": {
-        "id": "1400",
-        "payload": []
-      },
-      "continuous_stop": {
-        "id": "1401",
-        "payload": []
-      }
+            "index": "4-5"
+        },
+        {
+            "name": "src_device_id",
+            "type": "u8",
+            "index": "6"
+        },
+        {
+            "name": "dst_device_id",
+            "type": "u8",
+            "index": "7"
+        },
+        {
+            "name": "payload",
+            "type": "u8[]",
+            "index": "8-n"
+        },
+        {
+            "name": "checksum",
+            "type": "u16",
+            "index": "(n+1)-(n+2)"
+        }
+    ],
+    "messages": {
+        "ping1D": {
+            "undefined": {
+                "id": "0",
+                "payload": []
+            },
+            "ack": {
+                "id": "1",
+                "payload": []
+            },
+            "nack": {
+                "id": "2",
+                "payload": []
+            },
+            "ascii_text": {
+                "id": "3",
+                "payload": []
+            },
+            "set_device_id": {
+                "id": "1000",
+                "payload": [
+                    {
+                        "name": "device_id",
+                        "type": "u8"
+                    }
+                ]
+            },
+            "set_range": {
+                "id": "1001",
+                "payload": [
+                    {
+                        "name": "start_mm",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "length_mm",
+                        "type": "u8"
+                    }
+                ]
+            },
+            "set_speed_of_sound": {
+                "id": "1002",
+                "payload": [
+                    {
+                        "name": "speed",
+                        "type": "u32"
+                    }
+                ]
+            },
+            "set_auto_manual": {
+                "id": "1003",
+                "payload": [
+                    {
+                        "name": "mode",
+                        "type": "u8"
+                    }
+                ]
+            },
+            "set_ping_rate_msec": {
+                "id": "1004",
+                "payload": [
+                    {
+                        "name": "rate_msec",
+                        "type": "u16"
+                    }
+                ]
+            },
+            "set_gain_index": {
+                "id": "1005",
+                "payload": [
+                    {
+                        "name": "index",
+                        "type": "u8"
+                    }
+                ]
+            },
+            "set_ping_enable": {
+                "id": "1006",
+                "payload": [
+                    {
+                        "name": "enable",
+                        "type": "u8"
+                    }
+                ]
+            },
+            "goto_bootloader": {
+                "id": "1100",
+                "payload": []
+            },
+            "fw_version": {
+                "id": "1200",
+                "payload": [
+                    {
+                        "name": "device_type",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "device_model",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "fw_version_major",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "fw_version_minor",
+                        "type": "u16"
+                    }
+                ]
+            },
+            "device_id": {
+                "id": "1201",
+                "payload": [],
+                "deprecated": "true"
+            },
+            "voltage_5": {
+                "id": "1202",
+                "payload": [
+                    {
+                        "name": "mvolts",
+                        "type": "u16"
+                    }
+                ]
+            },
+            "speed_of_sound": {
+                "id": "1203",
+                "payload": [
+                    {
+                        "name": "speed_mmps",
+                        "type": "u32"
+                    }
+                ]
+            },
+            "range": {
+                "id": "1204",
+                "payload": [
+                    {
+                        "name": "start_mm",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "length_mm",
+                        "type": "u32"
+                    }
+                ]
+            },
+            "mode": {
+                "id": "1205",
+                "payload": [
+                    {
+                        "name": "auto_manual",
+                        "type": "u8"
+                    }
+                ]
+            },
+            "ping_rate_msec": {
+                "id": "1206",
+                "payload": [
+                    {
+                        "name": "msec_per_ping",
+                        "type": "u16"
+                    }
+                ]
+            },
+            "gain_index": {
+                "id": "1207",
+                "payload": [
+                    {
+                        "name": "gain_index",
+                        "type": "u8"
+                    }
+                ]
+            },
+            "pulse_usec": {
+                "id": "1208",
+                "payload": [
+                    {
+                        "name": "pulse_usec",
+                        "type": "u16"
+                    }
+                ]
+            },
+            "background_data": {
+                "id": "1209",
+                "payload": [
+                    {
+                        "name": "gain_index",
+                        "type": "u8"
+                    }
+                ]
+            },
+            "general_info": {
+                "id": "1210",
+                "payload": [
+                    {
+                        "name": "gain_index",
+                        "type": "u8"
+                    }
+                ]
+            },
+            "distance_simple": {
+                "id": "1211",
+                "payload": [
+                    {
+                        "name": "distance",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "confidence",
+                        "type": "u8"
+                    }
+                ]
+            },
+            "distance": {
+                "id": "1212",
+                "payload": [
+                    {
+                        "name": "distance",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "confidence",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "pulse_usec",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "ping_number",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "start_mm",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "length_mm",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "gain_index",
+                        "type": "u32"
+                    }
+                ]
+            },
+            "processor_temperature": {
+                "id": "1213",
+                "payload": [
+                    {
+                        "name": "temp",
+                        "type": "u16",
+                        "units": "centiC",
+                        "notes": "100 * degrees Centigrade"
+                    }
+                ]
+            },
+            "pcb_temperature": {
+                "id": "1214",
+                "payload": [
+                    {
+                        "name": "temp",
+                        "type": "u16",
+                        "units": "centiC",
+                        "notes": "PCB Board temperature, 100 * degrees Centigrade"
+                    }
+                ]
+            },
+            "profile": {
+                "id": "1300",
+                "payload": [
+                    {
+                        "name": "distance",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "confidence",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "pulse_usec",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "ping_number",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "start_mm",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "length_mm",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "gain_index",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "num_points",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "data",
+                        "type": "u8[200]"
+                    }
+                ]
+            },
+            "full_profile": {
+                "id": "1301",
+                "payload": [
+                    {
+                        "name": "this_ping_depth_mm",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "smoothed_depth_mm",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "smoothed_depth_confidence_percent",
+                        "type": "i8"
+                    },
+                    {
+                        "name": "this_ping_confidence_percent",
+                        "type": "i8"
+                    },
+                    {
+                        "name": "ping_duration_usec",
+                        "type": "i16"
+                    },
+                    {
+                        "name": "ping_number",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "supply_millivolts",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "degC",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "start_mm",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "length_mm",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "y0_mm",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "yn_mm",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "gain_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "outlier_bits",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "index_of_bottom_result",
+                        "type": "i16"
+                    },
+                    {
+                        "name": "num_results",
+                        "type": "i16"
+                    },
+                    {
+                        "name": "results",
+                        "type": "u8[200]"
+                    }
+                ]
+            },
+            "raw_data": {
+                "id": "1302",
+                "payload": [
+                    {
+                        "name": "v_major",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "v_minor",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "supply_millivolts",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "degC",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "gain_index",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "start_mm",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "len_mm",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "num_samples",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "ping_usec",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "ping_hz",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "adc_sample_hz",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "ping_num",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "rms_goertzel_noise",
+                        "type": "u32"
+                    }
+                ]
+            },
+            "continuous_start": {
+                "id": "1400",
+                "payload": []
+            },
+            "continuous_stop": {
+                "id": "1401",
+                "payload": []
+            }
+        }
     }
-  }
 }


### PR DESCRIPTION
The json format need to be `python -m json.tool` compatible with last version of 3.6 because of unsort-keys updates. 